### PR TITLE
step 8 : Define routing for entity administration

### DIFF
--- a/docs/cookbook/custom-model.rst
+++ b/docs/cookbook/custom-model.rst
@@ -185,7 +185,7 @@ should be also included in the ``app/config/routing.yml``.
 
     # app/config/routing/admin.yml
     app_admin_supplier:
-        resource: 'supplier.yml'
+        resource: 'admin/supplier.yml'
 
 .. code-block:: yaml
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Related tickets | fixes #X, partially #Y, mentioned in #Z |
| License | MIT |

"admin/" is missing in the "app/config/routing/admin.yml"  block
